### PR TITLE
Add project management process overview to docs/README.md

### DIFF
--- a/docs/docs_README_Version2.md
+++ b/docs/docs_README_Version2.md
@@ -1,0 +1,15 @@
+# OctoAcme Project Management Processes
+
+This repository standardizes OctoAcme’s project management practices, making them easily accessible for onboarding, collaboration, and continuous improvement.
+
+## Overview
+
+OctoAcme utilizes a transparent and structured approach to project management, guiding initiatives through lifecycle stages: initiation, planning, execution, release, and retrospective. Projects start with a concise one-pager that defines goals, stakeholders, success metrics, and key risks, then progress according to deliverable checklists to ensure consistency.
+
+Key roles include Project Manager, Product Manager, Developers, QA/Testers, and Stakeholders, each with well-defined responsibilities. The Project Manager orchestrates communication and risk management, while the Product Manager defines outcomes and backlog priorities. Developers contribute to implementation and quality, with QA/Testers ensuring criteria are met before release. Work is tracked on GitHub Projects boards, and features move through a PR process that stresses small, reviewable changes and automated CI validation.
+
+Project quality is maintained through extensive unit, integration, and end-to-end smoke tests, as well as security scanning and manual acceptance QA. Communication is frequent and multi-channeled: daily standups, weekly team syncs, and regular stakeholder updates, with risks reviewed and escalated via clear paths.
+
+Continuous improvement is fostered through structured retrospectives after milestones and incidents, capturing action items and lessons learned, and evolving the process documentation over time.
+
+For more details, refer to the specific guides in this folder.


### PR DESCRIPTION
Adds an overview of OctoAcme’s project management processes to docs/README.md as requested in [#2.](https://github.com/JayKuvardiya18/skills-scale-institutional-knowledge-using-copilot-spaces/issues/2)